### PR TITLE
Compatibility with Sails v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ which provides [grunt][] tasks for running and creating migrations. It also
 extracts the database configuration from the Sails config, so you don't have to
 duplicate you config in a `database.json` file.
 
-Supports Sails 0.10.x.
+Supports Sails 0.10.x and 1.x.x
 
 ## Setup
 
@@ -31,8 +31,10 @@ use to run migrations.
 ```JavaScript
 // config/migrations.js
 module.exports.migrations = {
-  // connection name matches a field from config/connections.js
-  connection: 'somePostgresqlServer' // or MySQL
+  // v0.10.x -> connection name matches a field from config/connections.js
+  connection: 'somePostgresqlServer', // or MySQL
+  // v1.x.x -> datastore name matches a field from config/datastores.js
+  datastore: 'somePostgresqlServer' // or MySQL
 };
 ```
 
@@ -44,8 +46,10 @@ file for the migrations instead of javascript file (defaults to `false`).
 ```JavaScript
 // config/migrations.js
 module.exports.migrations = {
-  // connection name matches a field from config/connections.js
+  // v0.10.x -> connection name matches a field from config/connections.js
   connection: 'somePostgresqlServer', // or MySQL
+  // v1.x.x -> datastore name matches a field from config/datastores.js
+  datastore: 'somePostgresqlServer' // or MySQL
   table: 'sails_migrations',
   migrationsDir: 'sails_migrations',
   coffeeFile: true

--- a/lib/sailsDbMigrate.js
+++ b/lib/sailsDbMigrate.js
@@ -77,15 +77,30 @@ function parseSailsConfig(sailsConfig) {
     throw new Error('Migrations not configured. Please setup ./config/migrations.js');
   }
 
-  var connectionName = sailsConfig.migrations.connection;
+  var connectionName = 
+    sailsConfig.migrations.datastore || 
+    // backwards compatibility: v0.10.x
+    sailsConfig.migrations.connection;
   if (!connectionName) {
-    throw new Error('connection missing from ./config/migrations.js');
+    throw new Error(
+      'Migrations not configured. Please specify either datastore (v1.x.x) or ' +
+      'connection (v0.10.x) in ./config/migrations.js'
+    );
+  }
+  
+  if (sailsConfig.connections) {
+    // backwards compatibility: v0.10.x
+    connection = sailsConfig.connections[connectionName]
+  } else if (sailsConfig.datastores) {
+    // v1.x.x
+    sailsConfig.datastores[connectionName]
   }
 
-  connection = sailsConfig.connections[connectionName];
-
   if (!connection) {
-    throw new Error('could not find connection ' + connectionName + ' in ./config/connections.js');
+    throw new Error(
+      `Migrations bad configuration. Could not find ${sailsConfig.connections ? 'connection' : 'datastore'} ` +
+      `'${connectionName}' in ./config/${sailsConfig.connections ? 'connections' : 'datastores'}.js`
+    );
   }
 
   // build the db url, which contains the password


### PR DESCRIPTION
- added compatibility for Sails v1
- allow to specify either `connection` or `datastore` option in configuration (to match sails v1 namings)
- improved error messages
